### PR TITLE
BUG FIX: rowQuantiles() should be called with a matrix (not a data.frame)

### DIFF
--- a/R/gonadMat-internal.R
+++ b/R/gonadMat-internal.R
@@ -19,7 +19,7 @@
   
   create_x <- cbind(1, data$x)
   x_fq     <- as.matrix(create_x) %*% t(as.matrix(cbind(A,B)))
-  pred_fq  <- as.data.frame(1 / (1 + exp(-x_fq)))
+  pred_fq  <- 1 / (1 + exp(-x_fq))
   qtl      <- round(matrixStats::rowQuantiles(pred_fq, probs = c(0.025, 0.5, 0.975)), 3)
   fitted   <- qtl[, 2]
   lower    <- qtl[, 1]
@@ -48,7 +48,7 @@
   
   create_x   <- cbind(1, data$x)
   x_bayes    <- as.matrix(create_x) %*% t(model_bayes)
-  pred_bayes <- as.data.frame(1 / (1 + exp(-x_bayes)))
+  pred_bayes <- 1 / (1 + exp(-x_bayes))
   qtl        <- round(matrixStats::rowQuantiles(pred_bayes, probs = c(0.025, 0.5, 0.975)), 3)
   fitted     <- qtl[, 2]
   lower      <- qtl[, 1]

--- a/R/morphMat-internal.R
+++ b/R/morphMat-internal.R
@@ -19,7 +19,7 @@
 
   create_x <- cbind(1, data$x)
   x_fq     <- as.matrix(create_x) %*% t(as.matrix(cbind(A,B)))
-  pred_fq  <- as.data.frame(1 / (1 + exp(-x_fq)))
+  pred_fq  <- 1 / (1 + exp(-x_fq))
   qtl      <- round(matrixStats::rowQuantiles(pred_fq, probs = c(0.025, 0.5, 0.975)), 3)
   fitted   <- qtl[, 2]
   lower    <- qtl[, 1]
@@ -48,7 +48,7 @@
   
   create_x   <- cbind(1, data$x)
   x_bayes    <- as.matrix(create_x) %*% t(model_bayes)
-  pred_bayes <- as.data.frame(1 / (1 + exp(-x_bayes)))
+  pred_bayes <- 1 / (1 + exp(-x_bayes))
   qtl        <- round(matrixStats::rowQuantiles(pred_bayes, probs = c(0.025, 0.5, 0.975)), 3)
   fitted     <- qtl[, 2]
   lower      <- qtl[, 1]


### PR DESCRIPTION
Hi,

calling it with a data.frame will produce an error in future versions of the matrixStats package, e.g.

```r
> library("sizeMat")
> example("gonad_mature")
> data(matFish)
> gonad_mat = gonad_mature(matFish, varNames = c("total_length", "stage_mat"), inmName = "I", 
gnd_mt+ matName = c("II", "III", "IV"), method = "fq", niter = 50)
Error in matrixStats::rowQuantiles(pred_fq, probs = c(0.025, 0.5, 0.975)) : 
  Argument 'x' is not a matrix: data.frame
```

The reason for this is that I'm tightening up the matrixStats package API to make it clear that it is optimized for matrices (and vectors) of type numeric and logical.  A data.frame is a completely different creature and often it does not even make sense to apply a function across the rows of a data.frame (since the columns are likely to be of different types).

Please submit an updated version of sizeMat to CRAN asap at your convenience.  I'm planning to submit the updated version of matrixStats to CRAN soon and would prefer not to break your packages.

Cheers

Henrik